### PR TITLE
タイマー開始時のサークルの表示を修正

### DIFF
--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
@@ -36,6 +36,7 @@ fun CircularProgressBar(
     animDuration: Int = 100,
     animDelay: Int = 0,
     onNumberClick: () -> Unit = {},
+    needCircleShow: Boolean,
 ) {
     var animationPlayed by remember {
         mutableStateOf(false)
@@ -60,6 +61,7 @@ fun CircularProgressBar(
                 .size(radius * 2f)
                 .testTag(TestTags.HOME_CIRCLE)
         ) {
+            if (needCircleShow) {
                 drawArc(
                     color = color,
                     -90f,
@@ -71,6 +73,7 @@ fun CircularProgressBar(
                     useCenter = false,
                     style = Stroke(strokeWidth.toPx(), cap = StrokeCap.Round)
                 )
+            }
         }
         Text(
             modifier = Modifier

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
@@ -63,7 +63,11 @@ fun CircularProgressBar(
             drawArc(
                 color = color,
                 -90f,
-                360 * curPercentage.value,
+                    if (curPercentage.value > 0) {
+                        360 * curPercentage.value
+                    } else {
+                        360 * 1f
+                    },
                 useCenter = false,
                 style = Stroke(strokeWidth.toPx(), cap = StrokeCap.Round)
             )

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/CircularProgressBar.kt
@@ -33,7 +33,7 @@ fun CircularProgressBar(
     radius: Dp = 50.dp,
     color: Color = Color.Green,
     strokeWidth: Dp = 8.dp,
-    animDuration: Int = 1000,
+    animDuration: Int = 100,
     animDelay: Int = 0,
     onNumberClick: () -> Unit = {},
 ) {
@@ -60,17 +60,17 @@ fun CircularProgressBar(
                 .size(radius * 2f)
                 .testTag(TestTags.HOME_CIRCLE)
         ) {
-            drawArc(
-                color = color,
-                -90f,
+                drawArc(
+                    color = color,
+                    -90f,
                     if (curPercentage.value > 0) {
                         360 * curPercentage.value
                     } else {
                         360 * 1f
                     },
-                useCenter = false,
-                style = Stroke(strokeWidth.toPx(), cap = StrokeCap.Round)
-            )
+                    useCenter = false,
+                    style = Stroke(strokeWidth.toPx(), cap = StrokeCap.Round)
+                )
         }
         Text(
             modifier = Modifier

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
@@ -106,7 +106,9 @@ fun HomeContent(
     }
 
     // For backup
-    var startedAt = startedTime ?: LocalDateTime.now()
+    var startedAt by remember {
+        mutableStateOf(startedTime ?: LocalDateTime.now())
+    }
 
     var deadLine by remember {
         mutableStateOf(deadline ?: Constants.DefaultDataTime)

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
@@ -94,6 +94,7 @@ fun HomeContent(
     deadline: LocalDateTime? = null,
     isVertical: Boolean = true,
 ) {
+    val primeColor = MaterialTheme.colors.primary
 
     var step by remember {
         mutableStateOf(
@@ -133,6 +134,11 @@ fun HomeContent(
                 cTime.toFloat() / milliSecondsBetween2DateTime(deadLine, startedAt)
             }
         )
+    }
+
+    // Circle bar color
+    var circleColor by remember {
+        mutableStateOf(Color.White)
     }
 
     // initialize
@@ -250,7 +256,7 @@ fun HomeContent(
 
         // タイマーの円
         CircularProgressBar(
-            percentage = if (cTime > 0) {
+            percentage = if (cTime > Constants.AdditionalTime) {
                 percentage
             } else {
                 1f
@@ -258,7 +264,7 @@ fun HomeContent(
             displayTime = formattedTimeFromMilliSeconds(cTime.toInt()),
             fontSize = 36.sp,
             radius = boxWithConstraintsScope.maxWidth / 2,
-            color = MaterialTheme.colors.primary,
+            color = circleColor,
             strokeWidth = strokeWidth,
             onNumberClick = {
                 // FIXME: 更新を通知するために無理矢理 NONE を挟んでいる
@@ -342,16 +348,30 @@ fun HomeContent(
         }
         SelectionStep.NONE, SelectionStep.DONE -> {}
     }
+
     // Timer
     LaunchedEffect(key1 = deadLine, key2 = cTime, key3 = isVertical) {
-        if (cTime > 0) {
+        if (cTime > Constants.AdditionalTime) {
             delay(Constants.TimerInterval)
             cTime = milliSecondsBetween2DateTime(deadLine, LocalDateTime.now())
 
             percentage = cTime.toFloat() / milliSecondsBetween2DateTime(deadLine, startedAt)
+
+            circleColor = when {
+                percentage < 1f / 6 -> {
+                    Color.Red
+                }
+                percentage < 3f / 6 -> {
+                    Color.Yellow
+                }
+                else -> {
+                    primeColor
+                }
+            }
         }
     }
 }
+
 
 /**
  * メイン画面のタイマーの選択状態を表すenumクラス。

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/module/main/view/HomeView.kt
@@ -136,9 +136,13 @@ fun HomeContent(
         )
     }
 
+    // サークルを表示させるかどうか
+    var needCircleShow by remember {
+        mutableStateOf(true)
+    }
     // Circle bar color
     var circleColor by remember {
-        mutableStateOf(Color.White)
+        mutableStateOf(primeColor)
     }
 
     // initialize
@@ -270,7 +274,8 @@ fun HomeContent(
                 // FIXME: 更新を通知するために無理矢理 NONE を挟んでいる
                 step = SelectionStep.NONE
                 step = SelectionStep.DATE
-            }
+            },
+            needCircleShow = needCircleShow,
         )
     }
 
@@ -329,10 +334,11 @@ fun HomeContent(
             selectedTime = time
             step = SelectionStep.DONE
 
+            // 必要な変数を初期化
             deadLine = LocalDateTime.of(selectedDate, selectedTime)
             startedAt = LocalDateTime.now()
-
             cTime = milliSecondsBetween2DateTime(deadLine, startedAt)
+            needCircleShow = true
 
             runBlocking {
                 presenter.onDateTimeRegistered(title.value, startedAt, deadLine)
@@ -368,6 +374,12 @@ fun HomeContent(
                     primeColor
                 }
             }
+        }
+        // 終了時刻後は、サークルを点灯させる
+        needCircleShow = if (Constants.AdditionalTime < cTime && cTime < 0) {
+            ((cTime / 1000) % 2).toInt() == 0
+        } else {
+            true
         }
     }
 }

--- a/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/util/Constants.kt
+++ b/app/src/main/java/jp/mydns/kokoichi0206/countdowntimer/util/Constants.kt
@@ -30,7 +30,9 @@ object Constants {
 
     val TokyoZoneOffset = ZoneOffset.ofHours(+9)
 
-    const val TimerInterval = 100L
+    const val TimerInterval = 10L
+    // 終了時刻後からループを継続する時間
+    const val AdditionalTime = -60_000L
 
     // In MoreVert
     const val DESCRIPTION_MORE_VERT_ICON = "MoreVert icon"


### PR DESCRIPTION
## UI

### 残り時間が半分以下
黄色で表示

<img width="475" alt="Screen Shot 2022-02-08 at 4 52 45" src="https://user-images.githubusercontent.com/52474650/152861430-5db4b9ce-cdbd-447a-bbbd-d22e8bccb677.png">


### 残り時間が 1/6 以下
赤色で表示

<img width="506" alt="Screen Shot 2022-02-08 at 4 51 46" src="https://user-images.githubusercontent.com/52474650/152861297-c508cff9-ccd1-4ab1-98fb-49cc4d7d2814.png">

